### PR TITLE
Live preview feature - Final implementation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+    <link href='https://fonts.googleapis.com/css?family=Urbanist' rel='stylesheet'>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/containers/FormStepper/index.js
+++ b/src/containers/FormStepper/index.js
@@ -60,13 +60,6 @@ function FormStepper({ steps }) {
     // settings and links are coming from the form present in each step of the stepper
     try {
       setLoading(true);
-      console.log(settings, links)
-      await new Promise((_, reject) => {
-        setTimeout(() => {
-          reject('failed successfully')
-          resetForm();
-        }, 3000);
-      })
       const { cid, filename: exportedFileName } = await api.exportLinks({
         title: settings.profileTitle,
         links: links,

--- a/src/containers/LastExported/index.js
+++ b/src/containers/LastExported/index.js
@@ -1,7 +1,7 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import PropTypes from "prop-types";
 
-import { generateIPFSFileURL } from "../../utils";
+import { generateIPFSFileURL, getFileNameFromIPFSResourceURI } from "../../utils";
 import './styles.css';
 /**
  * @description Renders last exported URL message for the user.
@@ -13,7 +13,7 @@ export default function LastExported({ cid, filename }) {
       <p>
         You can find your last exported page at:{" "}
         <a className="last-exported-url" target="_blank" rel="noopener noreferrer" href={ipfsUrl}>
-          {ipfsUrl}
+          {getFileNameFromIPFSResourceURI(ipfsUrl)}
         </a>
       </p>
     </div>

--- a/src/containers/LivePreview/index.js
+++ b/src/containers/LivePreview/index.js
@@ -14,7 +14,7 @@ function LivePreview() {
   const themeConfig = useThemeConfig(theme);
 
   if (themeConfig == null) {
-    return <Typography margin={2}>Loading...</Typography>;
+    return <Typography margin={2}>Loading Preview...</Typography>;
   }
 
   return (

--- a/src/containers/LivePreview/index.js
+++ b/src/containers/LivePreview/index.js
@@ -1,15 +1,26 @@
 // node modules
 import { Typography } from "@mui/material";
+import { ThemeProvider } from "styled-components";
 // user lib
+import { useAuth0Metadata } from "@contexts/auth0-metadata.context";
 import useFormValues from "@hooks/useFormValues";
 import useThemeConfig from "@hooks/useThemeConfig";
 // styles
-import { DeviceFrame } from "./styles";
+import {
+  DeviceFrame,
+  PreviewLinksContainer,
+  PreviewLinkButton,
+  PreviewLinksAvatar,
+  PreviewScreen,
+  PreviewProfileTitle,
+} from "./styles";
 
 function LivePreview() {
   const {
     settings: { theme, ...settings },
+    links,
   } = useFormValues();
+  const { metadata } = useAuth0Metadata();
 
   const themeConfig = useThemeConfig(theme);
 
@@ -19,8 +30,28 @@ function LivePreview() {
 
   return (
     <DeviceFrame>
-      {settings?.profileTitle != null && <p>{settings.profileTitle}</p>}
-      <p>{JSON.stringify(themeConfig, null, 2)}</p>
+      <ThemeProvider theme={themeConfig}>
+        <PreviewScreen>
+          <PreviewLinksAvatar src={metadata?.profilePicture} />
+          {settings?.profileTitle && (
+            <PreviewProfileTitle style={themeConfig?.title?.styles}>
+              {settings.profileTitle}
+            </PreviewProfileTitle>
+          )}
+          <PreviewLinksContainer>
+            {links.map((link, idx) => (
+              <PreviewLinkButton
+                key={`${link.title}-${idx}`}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {link?.title}
+              </PreviewLinkButton>
+            ))}
+          </PreviewLinksContainer>
+        </PreviewScreen>
+      </ThemeProvider>
     </DeviceFrame>
   );
 }

--- a/src/containers/LivePreview/index.js
+++ b/src/containers/LivePreview/index.js
@@ -1,11 +1,10 @@
 // node modules
-import { useMemo } from "react";
+import { Typography } from "@mui/material";
 // user lib
 import useFormValues from "@hooks/useFormValues";
+import useThemeConfig from "@hooks/useThemeConfig";
 // styles
 import { DeviceFrame } from "./styles";
-import { useThemePreviews } from "@contexts/theme-previews.context";
-import useThemeConfig from "@hooks/useThemeConfig";
 
 function LivePreview() {
   const {
@@ -15,7 +14,7 @@ function LivePreview() {
   const themeConfig = useThemeConfig(theme);
 
   if (themeConfig == null) {
-    return <p>Loading...</p>;
+    return <Typography margin={2}>Loading...</Typography>;
   }
 
   return (

--- a/src/containers/LivePreview/styles.js
+++ b/src/containers/LivePreview/styles.js
@@ -11,7 +11,6 @@ export const DeviceFrame = styled.div`
   top: 20%;
   transform-origin: top left;
   scale: 0.75;
-  /* transform: translateY(-50%) translate(-50%) translateZ(0); */
   width: 352px;
   &::after {
     background-image: url(${frame});

--- a/src/containers/LivePreview/styles.js
+++ b/src/containers/LivePreview/styles.js
@@ -55,14 +55,6 @@ export const PreviewLinksAvatar = styled.img`
   border: 2px solid ${({ theme }) => theme?.buttons?.bgColor ?? "inherit"};
   height: 128px;
   width: 128px;
-  &:hover {
-    background-color: ${({ theme }) =>
-      theme?.buttons?.bgColorHover ?? "inherit"};
-  }
-  &:active {
-    background-color: ${({ theme }) =>
-      theme?.buttons?.bgColorActive ?? "inherit"};
-  }
 `;
 
 export const PreviewLinksContainer = styled.div`

--- a/src/containers/LivePreview/styles.js
+++ b/src/containers/LivePreview/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import frame from '../../assets/preview-device.svg';
+import frame from "../../assets/preview-device.svg";
 
 export const DeviceFrame = styled.div`
   display: block;
@@ -7,10 +7,11 @@ export const DeviceFrame = styled.div`
   left: 50%;
   margin: 0 auto;
   padding: 16px;
+  font-family: "Urbanist", "Times New Roman", Times, serif !important;
   position: absolute;
-  top: 20%;
+  top: 10%;
+  scale: 0.85;
   transform-origin: top left;
-  scale: 0.75;
   width: 352px;
   &::after {
     background-image: url(${frame});
@@ -18,12 +19,67 @@ export const DeviceFrame = styled.div`
     background-repeat: no-repeat;
     background-size: contain;
     content: "";
-    inset: -24px;
+    inset: 0;
     pointer-events: none;
     position: absolute;
-    -webkit-background-size: contain;
-    -moz-background-size: contain;
-    -ms-background-size: contain;
-    -o-background-size: contain;
   }
 `;
+
+export const PreviewLinkButton = styled.a`
+  align-items: center;
+  border-radius: 5px;
+  color: ${({ theme }) => theme?.buttons?.textColor ?? "inherit"};
+  display: flex;
+  font-size: 1rem;
+  font-weight: 500;
+  justify-content: center;
+  margin: 8px 16px;
+  min-height: 50px;
+  text-decoration: none;
+  width: 250px;
+  background-color: ${({ theme }) => theme?.buttons?.bgColor ?? "inherit"};
+  &:hover {
+    cursor: pointer;
+    background-color: ${({ theme }) =>
+      theme?.buttons?.bgColorHover ?? "inherit"};
+  }
+  &:active {
+    background-color: ${({ theme }) =>
+      theme?.buttons?.bgColorActive ?? "inherit"};
+  }
+`;
+
+export const PreviewLinksAvatar = styled.img`
+  background-color: ${({ theme }) => theme?.buttons?.bgColor ?? "inherit"};
+  border-radius: 50%;
+  border: 2px solid ${({ theme }) => theme?.buttons?.bgColor ?? "inherit"};
+  height: 128px;
+  width: 128px;
+  &:hover {
+    background-color: ${({ theme }) =>
+      theme?.buttons?.bgColorHover ?? "inherit"};
+  }
+  &:active {
+    background-color: ${({ theme }) =>
+      theme?.buttons?.bgColorActive ?? "inherit"};
+  }
+`;
+
+export const PreviewLinksContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: scroll; 
+`;
+
+export const PreviewScreen = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: ${({ theme }) => theme?.buttons?.textColor ?? "inherit"};
+  background-color: ${({ theme }) => theme.container?.bgColor ?? "inherit"};
+  height: 100%;
+  padding: 24px;
+`;
+
+export const PreviewProfileTitle = styled.h1``;

--- a/src/containers/LivePreview/styles.js
+++ b/src/containers/LivePreview/styles.js
@@ -27,17 +27,22 @@ export const DeviceFrame = styled.div`
 
 export const PreviewLinkButton = styled.a`
   align-items: center;
+  background-color: ${({ theme }) => theme?.buttons?.bgColor ?? "inherit"};
   border-radius: 5px;
   color: ${({ theme }) => theme?.buttons?.textColor ?? "inherit"};
-  display: flex;
+  display: block;
   font-size: 1rem;
   font-weight: 500;
   justify-content: center;
   margin: 8px 16px;
   min-height: 50px;
+  overflow: hidden;
+  padding: 16px;
   text-decoration: none;
+  text-overflow: ellipsis;
+  text-align: center;
+  white-space: nowrap;
   width: 250px;
-  background-color: ${({ theme }) => theme?.buttons?.bgColor ?? "inherit"};
   &:hover {
     cursor: pointer;
     background-color: ${({ theme }) =>
@@ -61,7 +66,7 @@ export const PreviewLinksContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow-y: scroll; 
+  overflow-y: scroll;
 `;
 
 export const PreviewScreen = styled.section`

--- a/src/index.css
+++ b/src/index.css
@@ -17,13 +17,6 @@ body {
   /* background-color: rgb(67, 67, 67); */
 }
 
-h1,
-h2,
-h3,
-h6 {
-  color: var(--text-primary-color);
-}
-
 ul.unstyled {
   list-style-type: none;
   margin: 0;

--- a/src/pages/ExportLinksPage/styles.js
+++ b/src/pages/ExportLinksPage/styles.js
@@ -3,6 +3,9 @@ import styled from "styled-components";
 export const LinksPageContainer = styled.div`
   display: flex;
   margin: 16px 16px;
+  @media only screen and (max-width: 768px) {
+    flex-direction: column;
+  }
 `;
 
 export const PageLeftContent = styled.section`
@@ -10,10 +13,16 @@ export const PageLeftContent = styled.section`
   flex-direction: column;
   position: relative;
   width: 50%;
+  @media only screen and (max-width: 1280px) {
+    width: 40%;
+  }
 `;
 
 export const PageRightContent = styled.section`
   display: flex;
   position: relative;
   width: 50%;
+  @media screen and (max-width: 768px) {
+    transform: translate(-25%, 0);
+  }
 `;

--- a/src/utils.js
+++ b/src/utils.js
@@ -167,3 +167,12 @@ export function cleanUsername(username) {
 export function noop() {}
 
 //Let's get this adventure started, lads!
+
+/**
+ * @description Primarily used for extracting file name for last exported component.
+ * @param {string} uri 
+ * @returns {string}
+ */
+export function getFileNameFromIPFSResourceURI(uri) {
+  return uri.split('/').at(-1)
+}


### PR DESCRIPTION
This Pull request proposes the following changes:

- Implement `LivePreview` component that encapsulates the live theme preview screen
- Update the layout of `/export-links` page to be responsive with Live Preview
- Replace url of last exported page with a simplified file name :)
- Minor code refactors for consistency

Following is a short demo of the feature:


https://user-images.githubusercontent.com/36787866/204037006-0db0031d-9759-4f48-a00e-74ffe72460fc.mov

